### PR TITLE
Add config module for shared data type

### DIFF
--- a/backtest-modular.py
+++ b/backtest-modular.py
@@ -15,8 +15,9 @@ from finrl.meta.env_stock_trading.env_stocktrading import StockTradingEnv
 from finrl.meta.preprocessor.yahoodownloader import YahooDownloader
 
 # Hyperparameters and configuration
-DATA_TYPE='futures_data'
-# DATA_TYPE='reg_data'
+# DATA_TYPE is defined in config.py
+# Possible values include 'futures_data' or 'retail_data'
+from config import DATA_TYPE
 ALGOS_TO_USE    = ['a2c', 'ddpg', 'ppo', 'td3', 'sac']
 TRAIN_FILE      = f'{DATA_TYPE}/train_data.csv'
 BACKTEST_FILE   = f'{DATA_TYPE}/trade_data.csv'

--- a/config.py
+++ b/config.py
@@ -1,0 +1,5 @@
+"""Global configuration for training and backtesting scripts."""
+
+# Data folder to use for training and backtesting
+# Possible options include 'futures_data' or 'retail_data'
+DATA_TYPE = 'futures_data'

--- a/train.py
+++ b/train.py
@@ -11,8 +11,8 @@ from finrl.meta.env_stock_trading.env_stocktrading import StockTradingEnv
 # =========================
 # Configuration
 # =========================
-DATA_TYPE='futures_data'
-# DATA_TYPE='retail_data'
+# DATA_TYPE is defined in config.py
+from config import DATA_TYPE
 TRAINED_MODEL_DIR = f'{DATA_TYPE}/trained_models'
 RESULTS_DIR = f'{DATA_TYPE}/results'
 TRAIN_FILE        = f'{DATA_TYPE}/train_data.csv'  # Preprocessed training CSV


### PR DESCRIPTION
## Summary
- centralize DATA_TYPE in `config.py`
- import DATA_TYPE from new module in training and backtest scripts

## Testing
- `flake8` *(fails: many style violations)*
- `pytest -q` *(fails: missing pandas_market_calendars, gym, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685fac66d73c8331829a383b20b5ac70